### PR TITLE
fix rotary encoder rotation detection

### DIFF
--- a/tagtuner-D1-custom1.yaml
+++ b/tagtuner-D1-custom1.yaml
@@ -184,6 +184,7 @@ sensor:
     id: rotary
     pin_a: 18
     pin_b: 19
+    resolution: 2
     on_clockwise:
       - text_sensor.template.publish:
           id: status

--- a/tagtuner-XIAO-custom.yaml
+++ b/tagtuner-XIAO-custom.yaml
@@ -189,6 +189,7 @@ sensor:
     id: rotary
     pin_a: 19 #D8
     pin_b: 20 #D9
+    resolution: 2
     restore_mode: ALWAYS_ZERO
     on_clockwise:
       - text_sensor.template.publish:

--- a/tagtuner-atom-grove-ble.yaml
+++ b/tagtuner-atom-grove-ble.yaml
@@ -253,6 +253,7 @@ sensor:
     id: rotary
     pin_a: 25
     pin_b: 21
+    resolution: 2
     on_clockwise:
       - text_sensor.template.publish:
           id: status

--- a/tagtuner-atom-grove.yaml
+++ b/tagtuner-atom-grove.yaml
@@ -260,6 +260,7 @@ sensor:
     id: rotary
     pin_a: 25
     pin_b: 21
+    resolution: 2
     on_clockwise:
       - text_sensor.template.publish:
           id: status


### PR DESCRIPTION
With `KY-040` encoder (running with `ESP32-D1`) I've noticed that only every second rotation actually triggers a state change in logs/HA. Adding `resolution: 2` fixes that.

I've updated all configuration files with the same change with the assumption that all use the same encoder. If that's not the case then please let me know which changes to revert.